### PR TITLE
Fixed some API route namings

### DIFF
--- a/Articles/app/routes/article.js
+++ b/Articles/app/routes/article.js
@@ -4,7 +4,7 @@ const articleCtrl = require("../controllers/article.js");
 
 router.post("/create", articleCtrl.create);
 router.get("/", articleCtrl.getAll);
-router.get("/:id", articleCtrl.getKard);
+router.get("/:id", articleCtrl.getArticle);
 router.put("/:id", articleCtrl.update);
 router.delete("/:id", articleCtrl.delete);
 

--- a/Articles/package-lock.json
+++ b/Articles/package-lock.json
@@ -1,11 +1,11 @@
 {
- "name": "kards",
+ "name": "articles",
  "version": "1.0.0",
  "lockfileVersion": 2,
  "requires": true,
  "packages": {
   "": {
-   "name": "kards",
+   "name": "articles",
    "version": "1.0.0",
    "license": "ISC",
    "dependencies": {

--- a/Articles/package.json
+++ b/Articles/package.json
@@ -1,5 +1,5 @@
 {
- "name": "kards",
+ "name": "articles",
  "version": "1.0.0",
  "description": "",
  "main": "server.js",

--- a/Comments/app/routes/comment.js
+++ b/Comments/app/routes/comment.js
@@ -4,7 +4,7 @@ const commentCtrl = require("../controllers/comment.js");
 
 router.post("/create", commentCtrl.create);
 router.get("/", commentCtrl.getAll);
-router.get("/:id", commentCtrl.getKard);
+router.get("/:id", commentCtrl.getComment);
 router.put("/:id", commentCtrl.update);
 router.delete("/:id", commentCtrl.delete);
 

--- a/Comments/package-lock.json
+++ b/Comments/package-lock.json
@@ -1,11 +1,11 @@
 {
- "name": "kards",
+ "name": "comments",
  "version": "1.0.0",
  "lockfileVersion": 2,
  "requires": true,
  "packages": {
   "": {
-   "name": "kards",
+   "name": "comments",
    "version": "1.0.0",
    "license": "ISC",
    "dependencies": {

--- a/Comments/package.json
+++ b/Comments/package.json
@@ -1,5 +1,5 @@
 {
- "name": "kards",
+ "name": "comments",
  "version": "1.0.0",
  "description": "",
  "main": "server.js",

--- a/Posts/app/routes/post.js
+++ b/Posts/app/routes/post.js
@@ -4,7 +4,7 @@ const postCtrl = require("../controllers/post.js");
 
 router.post("/create", postCtrl.create);
 router.get("/", postCtrl.getAll);
-router.get("/:id", postCtrl.getKard);
+router.get("/:id", postCtrl.getPost);
 router.put("/:id", postCtrl.update);
 router.delete("/:id", postCtrl.delete);
 

--- a/Posts/package-lock.json
+++ b/Posts/package-lock.json
@@ -1,11 +1,11 @@
 {
- "name": "kards",
+ "name": "posts",
  "version": "1.0.0",
  "lockfileVersion": 2,
  "requires": true,
  "packages": {
   "": {
-   "name": "kards",
+   "name": "posts",
    "version": "1.0.0",
    "license": "ISC",
    "dependencies": {

--- a/Posts/package.json
+++ b/Posts/package.json
@@ -1,5 +1,5 @@
 {
- "name": "kards",
+ "name": "posts",
  "version": "1.0.0",
  "description": "",
  "main": "server.js",


### PR DESCRIPTION
Instances of "kard" (from a previous project) were still to be found and prevented the correct build of the Docker environment

Some remaining mentions of "kards" were replaced by their right counterparts in each micro-service package files